### PR TITLE
Correction for strict locations (rejections on iOS / Safari)

### DIFF
--- a/src/main/java/com/netiq/websockify/WebsockifyProxyHandler.java
+++ b/src/main/java/com/netiq/websockify/WebsockifyProxyHandler.java
@@ -473,7 +473,12 @@ public class WebsockifyProxyHandler extends SimpleChannelUpstreamHandler {
     }
 
     private String getWebSocketLocation(HttpRequest req) {
-        return "wss://" + req.getHeader(HttpHeaders.Names.HOST);
+        String prefix = "ws";
+        String origin = req.getHeader(HttpHeaders.Names.ORIGIN).toLowerCase();
+        if(origin.contains("https")){
+            prefix = "wss";
+        }
+        return prefix + "://" + req.getHeader(HttpHeaders.Names.HOST) + req.getUri();
     }
 
     @Override


### PR DESCRIPTION
I've found an issue where iOS and Safari will reject requests because their locations are not an exact match. It's easily fixed by ensuring that they match. I'm not sure if this is the best way to detect if `ws://` or `wss://` should be used, so I am open to suggestions beyond this.

You can see the error in the Safari console here: http://imgur.com/W6fgu

Netty controls what WebSocket draft spec will be used, but their code seems to gracefully (and correctly) handle Draft 76 - used by iOS and Safari. You may have to check that the version you are linked against supports Draft 76. I am just using the latest Netty for this right now (3.4.6 currently).
